### PR TITLE
Fix name of instance variable in ConfigValues entity

### DIFF
--- a/src/CgmConfigAdmin/Entity/ConfigValues.php
+++ b/src/CgmConfigAdmin/Entity/ConfigValues.php
@@ -19,7 +19,7 @@ class ConfigValues
     /**
      * @var string
      */
-    protected $values;
+    protected $value;
 
     /**
      * @param  string $id


### PR DESCRIPTION
Change `$values` to `$value` to match usage in mutator methods
